### PR TITLE
Fix token attribute typo

### DIFF
--- a/gpt-shell.py
+++ b/gpt-shell.py
@@ -25,7 +25,7 @@ class OpenAIHelper:
         self.client = OpenAI(api_key=self.api_key)
 
         self.max_tokens = max_tokens
-        self.remaning_tokens = max_tokens
+        self.remaining_tokens = max_tokens
         self.model_name = model_name
         self.all_messages = []
         self.set_model_for_encoding(model_name)
@@ -465,7 +465,7 @@ class Application:
         while True:
             try:
                 user_input = self.session.prompt(
-                    ANSI(colored(f"ChatGPT ({self.openai_helper.remaning_tokens}): ", "green")))
+                    ANSI(colored(f"ChatGPT ({self.openai_helper.remaining_tokens}): ", "green")))
                 if user_input.lower() == 'q':
                     break
                 self.interpret_and_execute_command(user_input)


### PR DESCRIPTION
## Summary
- rename `remaning_tokens` to `remaining_tokens`
- fix prompt to use the updated property

## Testing
- `python -m py_compile gpt-shell.py`


------
https://chatgpt.com/codex/tasks/task_e_683f4646f4d483258bf785aa52c6f134